### PR TITLE
Change to Phoenard.h to support Arduino IDE before 1.0.4

### DIFF
--- a/PHNMidi.cpp
+++ b/PHNMidi.cpp
@@ -42,7 +42,7 @@ void PHN_Midi::begin() {
 
   // Set default instrument bank and instrument ID
   talkMIDI(0xB0, 0x07, 125); //0xB0 is channel message, set channel volume to near max (127)
-  setInstrument(8); // Default instrument #8 - Clavi
+  setInstrument(7); // Default instrument #8 - Clavi (subtract 1 for setInstrument)
 }
 
 void PHN_Midi::setBank(byte bank) {

--- a/Phoenard.h
+++ b/Phoenard.h
@@ -33,6 +33,23 @@ THE SOFTWARE.
   #error "The Phoenard library only supports the ATMega 2560 CPU architecture"
 #endif
  
+#if(ARDUINO < 104)
+	// These array operators are included in hardware\arduino\avr\cores\arduino\new.h and new.cpp
+	// in newer Arduino distributions (1.0.4 and above)
+	#include <stdlib.h>
+	void * operator new[](size_t size);
+	void operator delete[](void * ptr);
+	// Normally, these would go in the .cpp file:
+	void * operator new[](size_t size) 
+	{ 
+		return malloc(size); 
+	} 
+	void operator delete[](void * ptr) 
+	{ 
+		free(ptr); 
+	} 
+#endif
+
 #include "PHNSettings.h"
 #include "PHNDisplayHardware.h"
 #include "PHNDisplay.h"

--- a/Phoenard.h
+++ b/Phoenard.h
@@ -28,6 +28,9 @@ THE SOFTWARE.
  * @brief Main include file for the Phoenard library
  */
 
+#ifndef Phoenard_h
+#define Phoenard_h
+
 // Compilation architecture check to prevent impossible to understand errors
 #ifndef __AVR_ATmega2560__
   #error "The Phoenard library only supports the ATMega 2560 CPU architecture"
@@ -61,3 +64,5 @@ THE SOFTWARE.
 
 // This includes <all> the widgets available in the Phoenard library
 #include "PHNWidgetAll.h"
+
+#endif

--- a/examples/TestRoutine/Tests.ino
+++ b/examples/TestRoutine/Tests.ino
@@ -744,6 +744,7 @@ TestResult testMIDI() {
 
   PHN_Midi midi;
   midi.begin();
+  midi.setInstrument(9); // Glockenspiel (was default with older PHNMidi library) 
   
   for (int i = 5; i >= 1; i--) {
     showCounter(i);


### PR DESCRIPTION
I think this is a reasonable place to put this since most Phoenard sketches include only this header file.  If there is a better place, please let me know.

In Phoenard.h, added array operators for new[] and delete[] for Arduino versions before 1.0.4.  (They are already included in versions 1.0.4 and above.)

Verified that example sketches now compile with Arduino 1.0.1, 1.0.3, 1.0.4, 1.0.6, and 1.6.5-r2.

Without this change, in Arduino 1.0.1 and 1.0.3, compilation fails with the following messages:
Phoenard\PHNWidget.cpp.o: In function `PHN_WidgetContainer::setWidgetCapacity(int)':
...\libraries\Phoenard/PHNWidget.cpp:230: undefined reference to`operator new[](unsigned int)'
...\libraries\Phoenard/PHNWidget.cpp:241: undefined reference to `operator delete[](void*)'
Phoenard\PHNWidget.cpp.o: In function`PHN_WidgetContainer::clearSilent()':
...\libraries\Phoenard/PHNWidget.cpp:219: undefined reference to `operator delete[](void*)'

Another commit includes additional updates for MIDI instrument numbering in PHNMidi.cpp and TestRoutine/Tests.ino

Another commit updates Phoenard.h to prevent multiple includes, using #ifndef and #define as used in other library header files.  I found this when trying to compile TestRoutine using Arduino 1.0.1.
